### PR TITLE
Change wallet encryption params for faster encryption

### DIFF
--- a/src/class/wallet.js
+++ b/src/class/wallet.js
@@ -1,4 +1,5 @@
 import EthWallet from 'ethereumjs-wallet';
+import { kdfParams } from '@/config';
 
 export class Wallet {
   constructor(v3) {
@@ -9,7 +10,7 @@ export class Wallet {
       return EthWallet.fromV3(v3, password, true).getPrivateKeyString();
     };
     this.exportToJSON = function (password, exportedV3Password) {
-      return EthWallet.fromV3(v3, password, true).toV3String(exportedV3Password);
+      return EthWallet.fromV3(v3, password, true).toV3String(exportedV3Password, kdfParams);
     };
     this.getAddressString = function() {
       return v3.address;

--- a/src/config/dev.env.js
+++ b/src/config/dev.env.js
@@ -1,5 +1,12 @@
 const userAPIUrl = 'http://user-url-for-dev.com';
 
+// Parameters for cipher encrypting wallet
+const kdfParams = {
+  kdf: 'scrypt',
+  n: 1024, // low for development
+}
+
 export default {
   userAPIUrl,
+  kdfParams,
 };

--- a/src/config/index.js
+++ b/src/config/index.js
@@ -7,7 +7,7 @@ switch (process.env.NODE_ENV) {
   case 'production':
     env = prodEnv;
     break;
-  
+
   default:
     env = {
       ...prodEnv,
@@ -23,4 +23,5 @@ export const {
   subscriptionsAPIInterval,
   subscriptionsBlockchainInterval,
   userAPIUrl,
+  kdfParams,
 } = env;

--- a/src/config/prod.env.js
+++ b/src/config/prod.env.js
@@ -11,6 +11,12 @@ const subscriptionsAPIInterval = 5000;
 const subscriptionsBlockchainInterval = 3000;
 const userAPIUrl = 'http://user-url-for-prod.com';
 
+// Parameters for cipher encrypting wallet
+const kdfParams = {
+  kdf: 'scrypt',
+  n: 8192,
+}
+
 export default {
   hdKeyMnemonic,
   infuraConf,
@@ -18,4 +24,5 @@ export default {
   subscriptionsAPIInterval,
   subscriptionsBlockchainInterval,
   userAPIUrl,
+  kdfParams,
 };

--- a/src/store/accounts/accounts.js
+++ b/src/store/accounts/accounts.js
@@ -3,7 +3,7 @@ import storage from '@/services/storage';
 import web3 from 'web3';
 import Bip39 from 'bip39';
 import HDKey from 'ethereumjs-wallet/hdkey';
-import { hdKeyMnemonic } from '@/config'
+import { hdKeyMnemonic, kdfParams } from '@/config'
 import EthWallet from 'ethereumjs-wallet';
 import { Wallet, Address } from '@/class' ;
 import { BigNumber } from 'bignumber.js';
@@ -90,12 +90,12 @@ export default {
     },
     addWalletWithV3({ commit, dispatch }, {json, key, walletPassword}) {
       const wallet = EthWallet.fromV3(json, key, true);
-      const newJson = wallet.toV3(new Buffer(walletPassword));
+      const newJson = wallet.toV3(new Buffer(walletPassword), kdfParams);
       dispatch('addWalletAndStore', newJson);
     },
     addWalletWithPrivateKey({ commit, dispatch }, {privateKey, password}) {
       const wallet = EthWallet.fromPrivateKey(Buffer.from(privateKey, 'hex'));
-      const json = wallet.toV3(new Buffer(password));
+      const json = wallet.toV3(new Buffer(password), kdfParams);
       dispatch('addWalletAndStore', json);
     },
     generateWallet({commit, dispatch, state}, password){
@@ -104,7 +104,7 @@ export default {
       }
       let i = Object.keys(state.wallets).length;
       let wallet = state.hdWallet.deriveChild(i).getWallet();
-      dispatch('addWalletAndStore', wallet.toV3(new Buffer(password)));
+      dispatch('addWalletAndStore', wallet.toV3(new Buffer(password), kdfParams));
     },
     addHdWallet({ commit, dispatch }, {key, password}) {
       const seed = Bip39.mnemonicToSeed(key);
@@ -112,7 +112,7 @@ export default {
       const hdWallet = hdKey.derivePath(hdKeyMnemonic.path);
       const wallet = hdWallet.deriveChild(0).getWallet();
       commit('addHdWallet', hdWallet);
-      dispatch('addWalletAndStore', wallet.toV3(new Buffer(password)));
+      dispatch('addWalletAndStore', wallet.toV3(new Buffer(password), kdfParams));
     },
     updateBalance({ commit, dispatch, state, rootState }) {
       if (state.address) {


### PR DESCRIPTION
In production, use 8192 iterations of scrypt, same as other web wallets