### PR TITLE
Don't get Otp settings when not logged in

### DIFF
--- a/src/components/TwoFactorAuthSettings.vue
+++ b/src/components/TwoFactorAuthSettings.vue
@@ -58,7 +58,16 @@ export default {
     TwoFactorAuthModal
   },
   mounted() {
-    this.getOtpSettings();
+    // make sure we have an email address (a proxy to see if we're logged in),
+    // before attempting to get Otp settings
+    // TODO: we should have a better mechanism for checking if we're logged in,
+    // or least a simple abstraction func, which would make the code more
+    // easily manageable, ie, when we want to change the logged in trigger from
+    // checking an email address to another attribute, we would only need to do
+    // it in one place
+    if (this.email) {
+      this.getOtpSettings();
+    }
   },
   mixins: [modalMixin],
 };


### PR DESCRIPTION
Fixes #118

When we are not logged in, we get a `401` response from `/identity/api/v1/otp` while trying to get otp settings. This adds a simple check to ensure we are logged in before trying to get otp settings.

This approach is the simple and easy fix, but one could argue for a more comprehensive fix. That would be an abstraction layer that is a computed function that check if we're logged in or not before attempting to make an API call to authenticated endpoints.

In addition, this PR (as of now), is without tests. I will add tests when people agree on what is the correct approach to fix this issue.