### PR TITLE
Fix transactions errors

### DIFF
--- a/src/store/transactions/actions.js
+++ b/src/store/transactions/actions.js
@@ -161,7 +161,8 @@ const handleBlockTransactions = (
   const userAddresses = rootGetters['accounts/accountAddresses'];
   const toUserTrx = transactions.filter(trx =>
     userAddresses.some(
-      address => toChecksumAddress(address) === toChecksumAddress(trx.to),
+      address =>
+        trx.to && toChecksumAddress(address) === toChecksumAddress(trx.to),
     ),
   );
 

--- a/src/store/web3/actions.js
+++ b/src/store/web3/actions.js
@@ -169,10 +169,10 @@ const handleLastBlock = async (
   if (handledBlockNumber === blockNumber) return;
 
   for (let i = handledBlockNumber + 1; i <= blockNumber; i += 1) {
-    web3.eth.getBlock(i, true).then(({ transactions }) => {
+    web3.eth.getBlock(i, true).then(res => {
       dispatch(
         'transactions/handleBlockTransactions',
-        { transactions, networkId },
+        { transactions: res.transactions || [], networkId },
         { root: true },
       );
     });


### PR DESCRIPTION
It relates to `null` transactions in `handleLastBlock` and `toChecksumAddress` with transaction without `to` property.